### PR TITLE
Fix minor bug which halts pair selection

### DIFF
--- a/deployment_notebooks/ACCESSaccount_deployment.ipynb
+++ b/deployment_notebooks/ACCESSaccount_deployment.ipynb
@@ -330,8 +330,8 @@
     "\n",
     "    # Report dictionaries for all valid products\n",
     "    if sorted_products == []: #Check if pairs were successfully selected\n",
-    "        raise Exception('No scenes meet spatial criteria'\n",
-    "                        'due to gaps and/or invalid input.'\n",
+    "        raise Exception('No scenes meet spatial criteria '\n",
+    "                        'due to gaps and/or invalid input. '\n",
     "                        'Nothing to export.')\n",
     "\n",
     "    # Combine polygons\n",
@@ -848,7 +848,8 @@
     "                                     minimum_path_intersection_km2=.1,#Overlap of common track union with respect to AOI in km2\n",
     "                                         )\n",
     "    if temp != []:\n",
-    "        iter_references_scenes = [temp[0]['reference']['start_date'][0]]\n",
+    "        iter_key = temp[0]['reference']['start_date'].keys()[0]\n",
+    "        iter_references_scenes = [temp[0]['reference']['start_date'][iter_key]]\n",
     "        if not any(x in iter_references_scenes for x in track_ref_dates):\n",
     "            track_ref_dates.extend(iter_references_scenes)            \n",
     "            ifg_pairs += temp"
@@ -888,7 +889,8 @@
     "                                             minimum_path_intersection_km2=.1,#Overlap of common track union with respect to AOI in km2\n",
     "                                                 )\n",
     "            if temp != []:\n",
-    "                iter_references_scenes = [temp[0]['reference']['start_date'][0]]\n",
+    "                iter_key = temp[0]['reference']['start_date'].keys()[0]\n",
+    "                iter_references_scenes = [temp[0]['reference']['start_date'][iter_key]]\n",
     "                if not any(x in iter_references_scenes for x in track_ref_dates):\n",
     "                    track_ref_dates.extend(iter_references_scenes)            \n",
     "                    ifg_pairs += temp"
@@ -975,7 +977,7 @@
     "    for index, row in df_pairs_gap_scenes_dict.iterrows():\n",
     "        fig, ax = plt.subplots()\n",
     "        p = gpd.GeoSeries(row['geometry'])\n",
-    "        p.exterior.plot(color='black', ax=ax, label=row['reference_date'][0])\n",
+    "        p.exterior.plot(color='black', ax=ax, label=row['reference_date'][0] + '_' + row['secondary_date'][0])\n",
     "        df_aoi.exterior.plot(color='red', ax=ax, label='AOI')\n",
     "        plt.legend()\n",
     "        plt.show"
@@ -1020,7 +1022,7 @@
     "    for index, row in df_pairs_rejected_scenes_dict.iterrows():\n",
     "        fig, ax = plt.subplots()\n",
     "        p = gpd.GeoSeries(row['geometry'])\n",
-    "        p.exterior.plot(color='black', ax=ax, label=row['reference_date'][0])\n",
+    "        p.exterior.plot(color='black', ax=ax, label=row['reference_date'][0] + '_' + row['secondary_date'][0])\n",
     "        df_aoi.exterior.plot(color='red', ax=ax, label='AOI')\n",
     "        plt.legend()\n",
     "        plt.show"

--- a/deployment_notebooks/Tibetaccount_deployment.ipynb
+++ b/deployment_notebooks/Tibetaccount_deployment.ipynb
@@ -325,8 +325,8 @@
     "\n",
     "    # Report dictionaries for all valid products\n",
     "    if sorted_products == []: #Check if pairs were successfully selected\n",
-    "        raise Exception('No scenes meet spatial criteria'\n",
-    "                        'due to gaps and/or invalid input.'\n",
+    "        raise Exception('No scenes meet spatial criteria '\n",
+    "                        'due to gaps and/or invalid input. '\n",
     "                        'Nothing to export.')\n",
     "\n",
     "    # Combine polygons\n",
@@ -843,7 +843,8 @@
     "                                     minimum_path_intersection_km2=.1,#Overlap of common track union with respect to AOI in km2\n",
     "                                         )\n",
     "    if temp != []:\n",
-    "        iter_references_scenes = [temp[0]['reference']['start_date'][0]]\n",
+    "        iter_key = temp[0]['reference']['start_date'].keys()[0]\n",
+    "        iter_references_scenes = [temp[0]['reference']['start_date'][iter_key]]\n",
     "        if not any(x in iter_references_scenes for x in track_ref_dates):\n",
     "            track_ref_dates.extend(iter_references_scenes)            \n",
     "            ifg_pairs += temp"
@@ -883,7 +884,8 @@
     "                                             minimum_path_intersection_km2=.1,#Overlap of common track union with respect to AOI in km2\n",
     "                                                 )\n",
     "            if temp != []:\n",
-    "                iter_references_scenes = [temp[0]['reference']['start_date'][0]]\n",
+    "                iter_key = temp[0]['reference']['start_date'].keys()[0]\n",
+    "                iter_references_scenes = [temp[0]['reference']['start_date'][iter_key]]\n",
     "                if not any(x in iter_references_scenes for x in track_ref_dates):\n",
     "                    track_ref_dates.extend(iter_references_scenes)            \n",
     "                    ifg_pairs += temp"
@@ -970,7 +972,7 @@
     "    for index, row in df_pairs_gap_scenes_dict.iterrows():\n",
     "        fig, ax = plt.subplots()\n",
     "        p = gpd.GeoSeries(row['geometry'])\n",
-    "        p.exterior.plot(color='black', ax=ax, label=row['reference_date'][0])\n",
+    "        p.exterior.plot(color='black', ax=ax, label=row['reference_date'][0] + '_' + row['secondary_date'][0])\n",
     "        df_aoi.exterior.plot(color='red', ax=ax, label='AOI')\n",
     "        plt.legend()\n",
     "        plt.show"
@@ -1015,7 +1017,7 @@
     "    for index, row in df_pairs_rejected_scenes_dict.iterrows():\n",
     "        fig, ax = plt.subplots()\n",
     "        p = gpd.GeoSeries(row['geometry'])\n",
-    "        p.exterior.plot(color='black', ax=ax, label=row['reference_date'][0])\n",
+    "        p.exterior.plot(color='black', ax=ax, label=row['reference_date'][0] + '_' + row['secondary_date'][0])\n",
     "        df_aoi.exterior.plot(color='red', ax=ax, label='AOI')\n",
     "        plt.legend()\n",
     "        plt.show"


### PR DESCRIPTION
Fix fringe error in pair enumeration step where a logic check fails if the first reference scene has an assigned index of >0:
```
KeyError: 0
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
File ~/Downloads/snap_setup/stable_oct5_2021/envs/s1-enumerator/lib/python3.10/site-packages/pandas/core/indexes/base.py:3621, in Index.get_loc(self, key, method, tolerance)
   3620 try:
-> 3621     return self._engine.get_loc(casted_key)
   3622 except KeyError as err:

File ~/Downloads/snap_setup/stable_oct5_2021/envs/s1-enumerator/lib/python3.10/site-packages/pandas/_libs/index.pyx:136, in pandas._libs.index.IndexEngine.get_loc()

File ~/Downloads/snap_setup/stable_oct5_2021/envs/s1-enumerator/lib/python3.10/site-packages/pandas/_libs/index.pyx:163, in pandas._libs.index.IndexEngine.get_loc()

File pandas/_libs/hashtable_class_helper.pxi:2131, in pandas._libs.hashtable.Int64HashTable.get_item()

File pandas/_libs/hashtable_class_helper.pxi:2140, in pandas._libs.hashtable.Int64HashTable.get_item()

KeyError: 0

The above exception was the direct cause of the following exception:

KeyError                                  Traceback (most recent call last)
Input In [158], in <cell line: 6>()
      7 temp = enumerate_ifgs_from_stack(df_stack_month,
      8                                  aoi,
      9                                  min_ref_date,
   (...)
     18                                  minimum_path_intersection_km2=.1,#Overlap of common track union with respect to AOI in km2
     19                                      )
     20 if temp != []:
---> 21     iter_references_scenes = [temp[0]['reference']['start_date'][0]]
     22     if not any(x in iter_references_scenes for x in track_ref_dates):
     23         track_ref_dates.extend(iter_references_scenes)            

File ~/Downloads/snap_setup/stable_oct5_2021/envs/s1-enumerator/lib/python3.10/site-packages/pandas/core/series.py:958, in Series.__getitem__(self, key)
    955     return self._values[key]
    957 elif key_is_scalar:
--> 958     return self._get_value(key)
    960 if is_hashable(key):
    961     # Otherwise index.get_value will raise InvalidIndexError
    962     try:
    963         # For labels that don't resolve as scalars like tuples and frozensets

File ~/Downloads/snap_setup/stable_oct5_2021/envs/s1-enumerator/lib/python3.10/site-packages/pandas/core/series.py:1069, in Series._get_value(self, label, takeable)
   1066     return self._values[label]
   1068 # Similar to Index.get_value, but we do not fall back to positional
-> 1069 loc = self.index.get_loc(label)
   1070 return self.index._get_values_for_loc(self, loc, label)

File ~/Downloads/snap_setup/stable_oct5_2021/envs/s1-enumerator/lib/python3.10/site-packages/pandas/core/indexes/base.py:3623, in Index.get_loc(self, key, method, tolerance)
   3621     return self._engine.get_loc(casted_key)
   3622 except KeyError as err:
-> 3623     raise KeyError(key) from err
   3624 except TypeError:
   3625     # If we have a listlike key, _check_indexing_error will raise
   3626     #  InvalidIndexError. Otherwise we fall through and re-raise
   3627     #  the TypeError.
   3628     self._check_indexing_error(key)

KeyError: 0
```


This is resolved by reseting the reference scene indices